### PR TITLE
Only sync active namespaces

### DIFF
--- a/pkg/kubesync/kubesync.go
+++ b/pkg/kubesync/kubesync.go
@@ -143,7 +143,9 @@ func (s *KubeSync) configmapSync() error {
 		s.promErrorCounter.Inc()
 		return err
 	}
-	allNamespaces, err := s.kubeClient.GetKubernetesClient().CoreV1().Namespaces().List(metav1.ListOptions{})
+	allNamespaces, err := s.kubeClient.GetKubernetesClient().CoreV1().Namespaces().List(metav1.ListOptions{
+		FieldSelector: "status.phase=Active",
+	})
 	if err != nil {
 		glog.Errorf("Cannot list all namespaces: %v", err)
 		s.promErrorCounter.Inc()


### PR DESCRIPTION
This avoids copying into namespaces that are terminating.

```
$ kgns
...
metrics-query                                     Active        1y
metrics-storage                                   Terminating   287d
mindy                                             Active        1y
...

$ kgns --field-selector="status.phase=Active"
...
metrics-query                                     Active   1y
mindy                                             Active   1y
...
```